### PR TITLE
fix: missing buttonText prop in ModalFooter

### DIFF
--- a/build/components/signup-modal.js
+++ b/build/components/signup-modal.js
@@ -95,7 +95,7 @@ var ModalFooter = (function (_React$Component2) {
         _react2["default"].createElement(
           "button",
           { type: "submit", className: "btn btn-primary btn-block btn-ghost" },
-          "Sign up"
+          this.props.buttonText
         )
       );
     }

--- a/js/components/signup-modal.jsx
+++ b/js/components/signup-modal.jsx
@@ -37,7 +37,7 @@ class ModalFooter extends React.Component {
   render() {
     return (
       <div className="modal-footer">
-        <button type="submit" className="btn btn-primary btn-block btn-ghost">Sign up</button>
+        <button type="submit" className="btn btn-primary btn-block btn-ghost">{this.props.buttonText}</button>
       </div>
     );
   }


### PR DESCRIPTION
I found a minor issue with ModalFooter. This PR fixes it by using props instead of hardcoded string.
