### PR TITLE
Removed link to malware sample page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Visit the Sample Page
 
-- [Hosted Sample Page](http://www.nealjs.com)
+- Sample Page - currently unavailable.
 - [Sample Page Code on Github](https://github.com/dennybritz/neal-sample)
 
 ## Available Components


### PR DESCRIPTION
The current sample page link tries to install malware. I've removed the link here -- we can put it back when the problem is fixed.